### PR TITLE
Update BluemConfiguration.php

### DIFF
--- a/src/Helpers/BluemConfiguration.php
+++ b/src/Helpers/BluemConfiguration.php
@@ -102,8 +102,8 @@ class BluemConfiguration
         
         $this->merchantID = $raw_validated->merchantID;
         $this->production_accessToken = $raw_validated->production_accessToken;
-        $this->expectedReturnStatus = $raw_validated->expectedReturnStatus;
-        $this->eMandateReason = $raw_validated->eMandateReason;
+        $this->expectedReturnStatus = $raw_validated->expectedReturnStatus ?? null;
+        $this->eMandateReason = $raw_validated->eMandateReason ?? null;
         $this->localInstrumentCode = $raw_validated->localInstrumentCode;
         $this->merchantSubID = "0";
     }


### PR DESCRIPTION
In production environment the property expectedReturnStatus is unset at line 174 of class Bluem\BluemPHP\Validators\BluemConfigurationValidator.
Laravel with PHP8 warns with exception "Undefined property: stdClass::$expectedReturnStatus". Same with eMandateReason.